### PR TITLE
Support array of classNames when adding entries

### DIFF
--- a/lib/features/palette/Palette.js
+++ b/lib/features/palette/Palette.js
@@ -168,7 +168,8 @@ Palette.prototype._update = function() {
       }
 
       if (entry.className) {
-        domClasses(control).add(entry.className);
+        const classNames = Array.isArray(entry.className ) ? entry.className : [ entry.className ];
+        classNames.forEach(e => domClasses(control).add(e));
       }
 
       if (entry.imageUrl) {


### PR DESCRIPTION
feat(palette): When adding entries, allow className to be an array of strings. 
